### PR TITLE
fix: Windows .cmd support and notification improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["climonitor contributors"]
 license = "MIT"
 repository = "https://github.com/kizaaku/climonitor"

--- a/examples/notifications/notify.ps1
+++ b/examples/notifications/notify.ps1
@@ -1,5 +1,5 @@
 # PowerShell Notification Script for climonitor
-# Windows Toast Notifications
+# Simple Windows balloon notification using System.Windows.Forms
 
 param(
     [string]$EventType,
@@ -8,72 +8,20 @@ param(
     [string]$Duration
 )
 
+Write-Host "Notification: $ToolName - $EventType - $Message"
+
 # ログファイルに記録
 $LogFile = "$env:USERPROFILE\.climonitor\notifications.log"
-$LogDir = Split-Path $LogFile -Parent
-if (-not (Test-Path $LogDir)) {
-    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+if (-not (Test-Path (Split-Path $LogFile))) {
+    New-Item -ItemType Directory -Path (Split-Path $LogFile) -Force | Out-Null
 }
+Add-Content -Path $LogFile -Value "$(Get-Date) - $EventType $ToolName $Message"
 
-$LogEntry = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - event_type=$EventType, tool=$ToolName, message=$Message, duration=$Duration"
-Add-Content -Path $LogFile -Value $LogEntry
-
-# Windows Toast通知関数
-function Show-ToastNotification {
-    param(
-        [string]$Title,
-        [string]$Body
-    )
-    
-    try {
-        # Windows Runtime API を読み込み
-        [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-        
-        # トーストテンプレートを取得
-        $Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
-        $RawXml = [xml] $Template.GetXml()
-        
-        # テキストを設定
-        ($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq "1"}).AppendChild($RawXml.CreateTextNode($Title)) | Out-Null
-        ($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq "2"}).AppendChild($RawXml.CreateTextNode($Body)) | Out-Null
-        
-        # 音声を追加
-        $AudioNode = $RawXml.CreateElement("audio")
-        $AudioNode.SetAttribute("src", "ms-winsoundevent:Notification.Default")
-        $RawXml.toast.AppendChild($AudioNode) | Out-Null
-        
-        # 通知を作成して表示
-        $SerializedXml = New-Object Windows.Data.Xml.Dom.XmlDocument
-        $SerializedXml.LoadXml($RawXml.OuterXml)
-        $Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
-        $Toast.Tag = "climonitor"
-        $Toast.Group = "climonitor"
-        $Toast.SuppressPopup = $false
-        
-        $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("climonitor")
-        $Notifier.Show($Toast)
-    }
-    catch {
-        # Toast通知が失敗した場合はバルーン通知にフォールバック
-        Write-Host "Toast notification failed, using fallback: $Title - $Body"
-    }
-}
-
-# イベントタイプに応じた通知
-switch ($EventType) {
-    "waiting_for_input" {
-        Show-ToastNotification -Title "$ToolName が入力待ち" -Body $Message
-    }
-    "error" {
-        Show-ToastNotification -Title "$ToolName エラー" -Body "エラーが発生しました: $Message"
-    }
-    "completed" {
-        Show-ToastNotification -Title "$ToolName 完了" -Body $Message
-    }
-    "status_change" {
-        Show-ToastNotification -Title "$ToolName 状態変化" -Body $Message
-    }
-    default {
-        Show-ToastNotification -Title "climonitor" -Body "$ToolName: $Message"
-    }
-}
+# シンプルなバルーン通知
+Add-Type -AssemblyName System.Windows.Forms
+$notification = New-Object System.Windows.Forms.NotifyIcon
+$notification.Icon = [System.Drawing.SystemIcons]::Information
+$notification.Visible = $true
+$notification.ShowBalloonTip(3000, $ToolName, $Message, [System.Windows.Forms.ToolTipIcon]::Info)
+Start-Sleep -Seconds 4
+$notification.Dispose()

--- a/examples/notifications/notify.ps1
+++ b/examples/notifications/notify.ps1
@@ -1,0 +1,79 @@
+# PowerShell Notification Script for climonitor
+# Windows Toast Notifications
+
+param(
+    [string]$EventType,
+    [string]$ToolName, 
+    [string]$Message,
+    [string]$Duration
+)
+
+# ログファイルに記録
+$LogFile = "$env:USERPROFILE\.climonitor\notifications.log"
+$LogDir = Split-Path $LogFile -Parent
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$LogEntry = "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - event_type=$EventType, tool=$ToolName, message=$Message, duration=$Duration"
+Add-Content -Path $LogFile -Value $LogEntry
+
+# Windows Toast通知関数
+function Show-ToastNotification {
+    param(
+        [string]$Title,
+        [string]$Body
+    )
+    
+    try {
+        # Windows Runtime API を読み込み
+        [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+        
+        # トーストテンプレートを取得
+        $Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+        $RawXml = [xml] $Template.GetXml()
+        
+        # テキストを設定
+        ($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq "1"}).AppendChild($RawXml.CreateTextNode($Title)) | Out-Null
+        ($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq "2"}).AppendChild($RawXml.CreateTextNode($Body)) | Out-Null
+        
+        # 音声を追加
+        $AudioNode = $RawXml.CreateElement("audio")
+        $AudioNode.SetAttribute("src", "ms-winsoundevent:Notification.Default")
+        $RawXml.toast.AppendChild($AudioNode) | Out-Null
+        
+        # 通知を作成して表示
+        $SerializedXml = New-Object Windows.Data.Xml.Dom.XmlDocument
+        $SerializedXml.LoadXml($RawXml.OuterXml)
+        $Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
+        $Toast.Tag = "climonitor"
+        $Toast.Group = "climonitor"
+        $Toast.SuppressPopup = $false
+        
+        $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("climonitor")
+        $Notifier.Show($Toast)
+    }
+    catch {
+        # Toast通知が失敗した場合はバルーン通知にフォールバック
+        Write-Host "Toast notification failed, using fallback: $Title - $Body"
+    }
+}
+
+# イベントタイプに応じた通知
+switch ($EventType) {
+    "waiting_for_input" {
+        Show-ToastNotification -Title "$ToolName が入力待ち" -Body $Message
+    }
+    "error" {
+        Show-ToastNotification -Title "$ToolName エラー" -Body "エラーが発生しました: $Message"
+    }
+    "completed" {
+        Show-ToastNotification -Title "$ToolName 完了" -Body $Message
+    }
+    "status_change" {
+        Show-ToastNotification -Title "$ToolName 状態変化" -Body $Message
+    }
+    default {
+        Show-ToastNotification -Title "climonitor" -Body "$ToolName: $Message"
+    }
+}

--- a/monitor/src/notification.rs
+++ b/monitor/src/notification.rs
@@ -17,13 +17,13 @@ impl NotificationManager {
     fn find_notification_script() -> Option<PathBuf> {
         if let Some(home) = home::home_dir() {
             let climonitor_dir = home.join(".climonitor");
-            
+
             // プラットフォーム固有のスクリプトを検索
             #[cfg(windows)]
             let script_name = "notify.ps1";
             #[cfg(not(windows))]
             let script_name = "notify.sh";
-            
+
             let script = climonitor_dir.join(script_name);
             if script.exists() && script.is_file() {
                 return Some(script);
@@ -70,7 +70,7 @@ impl NotificationManager {
                 .arg(&duration)
                 .output()
                 .await;
-                
+
             #[cfg(not(windows))]
             let result = Command::new("sh")
                 .arg(&script_path)


### PR DESCRIPTION
## Summary
- Fix Gemini CLI execution on Windows when monitor server is not available
- Add Windows .cmd file support in run_directly method
- Simplify Windows notification system with reliable balloon notifications
- Bump version to 0.5.1

## Changes
- **Windows .cmd support**: Use cmd.exe wrapper for direct execution similar to PTY execution
- **Notification improvements**: Replace complex Toast API with simple System.Windows.Forms balloon notifications
- **Code quality**: Apply cargo fmt and clippy fixes

## Test plan
- [ ] Test Gemini CLI execution on Windows (both with and without monitor server)
- [ ] Test Windows notification functionality
- [ ] Verify cross-platform compatibility
- [ ] Run CI tests

Fixes issue where `climonitor-launcher gemini` would fail with "program not found" when monitor server connection failed.

🤖 Generated with [Claude Code](https://claude.ai/code)