### PR TITLE
fix: Prevent direct Connected→Idle state transitions in Claude sessions

### DIFF
--- a/launcher/src/screen_claude_detector.rs
+++ b/launcher/src/screen_claude_detector.rs
@@ -40,6 +40,9 @@ impl ScreenClaudeStateDetector {
     }
 
     /// Claude固有の完了状態検出: "esc to interrupt"の有無で判定
+    /// 
+    /// Claudeは連続処理時に"esc to interrupt"が一瞬消えることがあるため、
+    /// 真の状態変化（開始/完了）のみを検出してちらつきを防ぐ
     fn detect_claude_completion_state(&mut self) -> Option<SessionStatus> {
         // UIボックス近辺での"esc to interrupt)"検出のみ
         let ui_boxes = self.screen_buffer.find_ui_boxes();
@@ -69,7 +72,7 @@ impl ScreenClaudeStateDetector {
         if self.previous_had_esc_interrupt && !has_esc_interrupt {
             // "esc to interrupt"が消えた = 実行完了
             if self.verbose {
-                eprintln!("✅ [CLAUDE_COMPLETION] 'esc to interrupt' disappeared → Completing");
+                eprintln!("✅ [CLAUDE_COMPLETION] 'esc to interrupt' disappeared → Idle");
             }
             self.last_state_change = Some(now);
             self.previous_had_esc_interrupt = false;

--- a/launcher/src/screen_claude_detector.rs
+++ b/launcher/src/screen_claude_detector.rs
@@ -40,7 +40,7 @@ impl ScreenClaudeStateDetector {
     }
 
     /// Claude固有の完了状態検出: "esc to interrupt"の有無で判定
-    /// 
+    ///
     /// Claudeは連続処理時に"esc to interrupt"が一瞬消えることがあるため、
     /// 真の状態変化（開始/完了）のみを検出してちらつきを防ぐ
     fn detect_claude_completion_state(&mut self) -> Option<SessionStatus> {

--- a/launcher/src/transport_client.rs
+++ b/launcher/src/transport_client.rs
@@ -638,8 +638,16 @@ impl TransportLauncherClient {
             let should_notify = {
                 if let Ok(mut last_status) = last_notified_status.lock() {
                     if current_status != *last_status {
-                        *last_status = current_status.clone();
-                        true
+                        // Connected→Idle の直接遷移を防ぐ
+                        if *last_status == SessionStatus::Connected && current_status == SessionStatus::Idle {
+                            if verbose {
+                                eprintln!("🔒 [STATE_TRANSITION] Blocked Connected→Idle transition, keeping Connected");
+                            }
+                            false // 状態変化を通知しない（Connected状態を維持）
+                        } else {
+                            *last_status = current_status.clone();
+                            true
+                        }
                     } else {
                         false
                     }

--- a/launcher/src/transport_client.rs
+++ b/launcher/src/transport_client.rs
@@ -639,7 +639,9 @@ impl TransportLauncherClient {
                 if let Ok(mut last_status) = last_notified_status.lock() {
                     if current_status != *last_status {
                         // Connected→Idle の直接遷移を防ぐ
-                        if *last_status == SessionStatus::Connected && current_status == SessionStatus::Idle {
+                        if *last_status == SessionStatus::Connected
+                            && current_status == SessionStatus::Idle
+                        {
                             if verbose {
                                 eprintln!("🔒 [STATE_TRANSITION] Blocked Connected→Idle transition, keeping Connected");
                             }

--- a/launcher/tests/test_connected_state_transition.rs
+++ b/launcher/tests/test_connected_state_transition.rs
@@ -1,0 +1,130 @@
+// Connected状態からBusy状態のみに遷移できることをテストする
+
+use climonitor_launcher::screen_claude_detector::ScreenClaudeStateDetector;
+use climonitor_launcher::state_detector::StateDetector;
+use climonitor_shared::SessionStatus;
+
+#[test]
+fn test_connected_state_maintained_without_execution() {
+    let mut detector = ScreenClaudeStateDetector::new(false);
+    
+    // 初期状態はConnected
+    assert_eq!(*detector.current_state(), SessionStatus::Connected);
+    
+    // Claude起動後の通常のUI表示（"esc to interrupt"なし）
+    let idle_ui_sequence = [
+        // UIボックス表示
+        "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
+    ];
+    
+    for line in idle_ui_sequence.iter() {
+        let result = detector.process_output(line);
+        // 状態変化が発生しないことを確認
+        assert!(result.is_none(), "Should not change state from Connected without 'esc to interrupt'");
+    }
+    
+    // Connected状態が維持されることを確認
+    assert_eq!(*detector.current_state(), SessionStatus::Connected, 
+               "Should maintain Connected state when no execution occurs");
+}
+
+#[test]
+fn test_connected_to_busy_transition() {
+    let mut detector = ScreenClaudeStateDetector::new(false);
+    
+    // 初期状態はConnected
+    assert_eq!(*detector.current_state(), SessionStatus::Connected);
+    
+    // "esc to interrupt"が表示される = 実行開始
+    let busy_sequence = [
+        // 実行中表示
+        "\x1b[38;2;215;119;87m·\x1b[39m \x1b[38;2;215;119;87mThinking… \x1b[38;2;153;153;153m(1s · \x1b[1mesc \x1b[22mto interrupt)\x1b[39m\r\n",
+        // UIボックス
+        "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
+    ];
+    
+    let mut state_changed = false;
+    for line in busy_sequence.iter() {
+        if let Some(new_state) = detector.process_output(line) {
+            assert_eq!(new_state, SessionStatus::Busy, "Should transition to Busy when 'esc to interrupt' appears");
+            state_changed = true;
+        }
+    }
+    
+    assert!(state_changed, "State should change from Connected to Busy");
+    assert_eq!(*detector.current_state(), SessionStatus::Busy);
+}
+
+#[test]
+fn test_busy_to_idle_transition() {
+    let mut detector = ScreenClaudeStateDetector::new(true); // verboseモード
+    
+    // Connected→Busyの遷移を正しく行う
+    let busy_sequence = [
+        // "esc to interrupt"を含む行
+        "\x1b[38;2;215;119;87m·\x1b[39m \x1b[38;2;215;119;87mThinking… \x1b[38;2;153;153;153m(1s · \x1b[1mesc \x1b[22mto interrupt)\x1b[39m\r\n",
+        // UIボックス（above_lines扱い）
+        "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
+    ];
+    
+    // Busy状態に遷移させる
+    for line in busy_sequence.iter() {
+        detector.process_output(line);
+    }
+    
+    println!("Current state after busy sequence: {:?}", detector.current_state());
+    
+    // Busy状態になっていることを確認
+    assert_eq!(*detector.current_state(), SessionStatus::Busy);
+    
+    // "esc to interrupt"が消える = 実行完了
+    let idle_sequence = [
+        // 実行完了後のUI（"esc to interrupt"なし）
+        "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
+    ];
+    
+    let mut state_changed = false;
+    for line in idle_sequence.iter() {
+        if let Some(new_state) = detector.process_output(line) {
+            assert_eq!(new_state, SessionStatus::Idle, "Should transition to Idle when 'esc to interrupt' disappears");
+            state_changed = true;
+        }
+    }
+    
+    assert!(state_changed, "State should change from Busy to Idle");
+    assert_eq!(*detector.current_state(), SessionStatus::Idle);
+}
+
+#[test]
+fn test_no_direct_connected_to_idle_transition() {
+    let mut detector = ScreenClaudeStateDetector::new(false);
+    
+    // 初期状態はConnected
+    assert_eq!(*detector.current_state(), SessionStatus::Connected);
+    
+    // Idleになりそうな状況を再現（UIボックスはあるが"esc to interrupt"なし）
+    let sequence = [
+        "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > Ready for input\x1b[39m                  \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
+        "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
+    ];
+    
+    for line in sequence.iter() {
+        let result = detector.process_output(line);
+        // Connected→Idleの直接遷移は発生しない
+        assert!(result.is_none() || result != Some(SessionStatus::Idle), 
+                "Should not transition directly from Connected to Idle");
+    }
+    
+    // Connected状態が維持される
+    assert_eq!(*detector.current_state(), SessionStatus::Connected, 
+               "Should maintain Connected state, not transition to Idle");
+}

--- a/launcher/tests/test_connected_state_transition.rs
+++ b/launcher/tests/test_connected_state_transition.rs
@@ -7,10 +7,10 @@ use climonitor_shared::SessionStatus;
 #[test]
 fn test_connected_state_maintained_without_execution() {
     let mut detector = ScreenClaudeStateDetector::new(false);
-    
+
     // 初期状態はConnected
     assert_eq!(*detector.current_state(), SessionStatus::Connected);
-    
+
     // Claude起動後の通常のUI表示（"esc to interrupt"なし）
     let idle_ui_sequence = [
         // UIボックス表示
@@ -18,25 +18,31 @@ fn test_connected_state_maintained_without_execution() {
         "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
     ];
-    
+
     for line in idle_ui_sequence.iter() {
         let result = detector.process_output(line);
         // 状態変化が発生しないことを確認
-        assert!(result.is_none(), "Should not change state from Connected without 'esc to interrupt'");
+        assert!(
+            result.is_none(),
+            "Should not change state from Connected without 'esc to interrupt'"
+        );
     }
-    
+
     // Connected状態が維持されることを確認
-    assert_eq!(*detector.current_state(), SessionStatus::Connected, 
-               "Should maintain Connected state when no execution occurs");
+    assert_eq!(
+        *detector.current_state(),
+        SessionStatus::Connected,
+        "Should maintain Connected state when no execution occurs"
+    );
 }
 
 #[test]
 fn test_connected_to_busy_transition() {
     let mut detector = ScreenClaudeStateDetector::new(false);
-    
+
     // 初期状態はConnected
     assert_eq!(*detector.current_state(), SessionStatus::Connected);
-    
+
     // "esc to interrupt"が表示される = 実行開始
     let busy_sequence = [
         // 実行中表示
@@ -46,15 +52,19 @@ fn test_connected_to_busy_transition() {
         "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
     ];
-    
+
     let mut state_changed = false;
     for line in busy_sequence.iter() {
         if let Some(new_state) = detector.process_output(line) {
-            assert_eq!(new_state, SessionStatus::Busy, "Should transition to Busy when 'esc to interrupt' appears");
+            assert_eq!(
+                new_state,
+                SessionStatus::Busy,
+                "Should transition to Busy when 'esc to interrupt' appears"
+            );
             state_changed = true;
         }
     }
-    
+
     assert!(state_changed, "State should change from Connected to Busy");
     assert_eq!(*detector.current_state(), SessionStatus::Busy);
 }
@@ -62,7 +72,7 @@ fn test_connected_to_busy_transition() {
 #[test]
 fn test_busy_to_idle_transition() {
     let mut detector = ScreenClaudeStateDetector::new(true); // verboseモード
-    
+
     // Connected→Busyの遷移を正しく行う
     let busy_sequence = [
         // "esc to interrupt"を含む行
@@ -72,17 +82,20 @@ fn test_busy_to_idle_transition() {
         "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
     ];
-    
+
     // Busy状態に遷移させる
     for line in busy_sequence.iter() {
         detector.process_output(line);
     }
-    
-    println!("Current state after busy sequence: {:?}", detector.current_state());
-    
+
+    println!(
+        "Current state after busy sequence: {:?}",
+        detector.current_state()
+    );
+
     // Busy状態になっていることを確認
     assert_eq!(*detector.current_state(), SessionStatus::Busy);
-    
+
     // "esc to interrupt"が消える = 実行完了
     let idle_sequence = [
         // 実行完了後のUI（"esc to interrupt"なし）
@@ -90,15 +103,19 @@ fn test_busy_to_idle_transition() {
         "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > \x1b[39m\x1b[7m \x1b[27m                                        \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
     ];
-    
+
     let mut state_changed = false;
     for line in idle_sequence.iter() {
         if let Some(new_state) = detector.process_output(line) {
-            assert_eq!(new_state, SessionStatus::Idle, "Should transition to Idle when 'esc to interrupt' disappears");
+            assert_eq!(
+                new_state,
+                SessionStatus::Idle,
+                "Should transition to Idle when 'esc to interrupt' disappears"
+            );
             state_changed = true;
         }
     }
-    
+
     assert!(state_changed, "State should change from Busy to Idle");
     assert_eq!(*detector.current_state(), SessionStatus::Idle);
 }
@@ -106,25 +123,30 @@ fn test_busy_to_idle_transition() {
 #[test]
 fn test_no_direct_connected_to_idle_transition() {
     let mut detector = ScreenClaudeStateDetector::new(false);
-    
+
     // 初期状態はConnected
     assert_eq!(*detector.current_state(), SessionStatus::Connected);
-    
+
     // Idleになりそうな状況を再現（UIボックスはあるが"esc to interrupt"なし）
     let sequence = [
         "\x1b[2m\x1b[38;2;136;136;136m╭─────────────────────────────────────────╮\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m│\x1b[22m\x1b[38;2;153;153;153m > Ready for input\x1b[39m                  \x1b[2m\x1b[38;2;136;136;136m│\x1b[39m\x1b[22m\r\n",
         "\x1b[2m\x1b[38;2;136;136;136m╰─────────────────────────────────────────╯\x1b[39m\x1b[22m\r\n",
     ];
-    
+
     for line in sequence.iter() {
         let result = detector.process_output(line);
         // Connected→Idleの直接遷移は発生しない
-        assert!(result.is_none() || result != Some(SessionStatus::Idle), 
-                "Should not transition directly from Connected to Idle");
+        assert!(
+            result.is_none() || result != Some(SessionStatus::Idle),
+            "Should not transition directly from Connected to Idle"
+        );
     }
-    
+
     // Connected状態が維持される
-    assert_eq!(*detector.current_state(), SessionStatus::Connected, 
-               "Should maintain Connected state, not transition to Idle");
+    assert_eq!(
+        *detector.current_state(),
+        SessionStatus::Connected,
+        "Should maintain Connected state, not transition to Idle"
+    );
 }


### PR DESCRIPTION
## Summary
- Block Connected→Idle transitions in periodic_state_checker to maintain Connected state when Claude starts but hasn't executed anything yet
- Add comprehensive test coverage for state transition constraints  
- Add comments explaining flicker prevention logic in state detector
- Ensures Claude sessions show "Connected" until first execution begins

## Test plan
- [x] Run all existing tests (`cargo test`)
- [x] Run new state transition tests
- [x] Code formatting (`cargo fmt`) 
- [x] Linting (`cargo clippy`)
- [x] Manual testing with climonitor + Claude Code

This restores the intuitive behavior where newly started Claude sessions remain in Connected state rather than immediately showing as "Completed".

🤖 Generated with [Claude Code](https://claude.ai/code)